### PR TITLE
Added react native compatibility

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,18 +14,18 @@ const ReactTimer = ({
 
   useEffect(() => {
     if (!timerRef.current) {
-      timerRef.current = window.setInterval(() => {
+      timerRef.current = setInterval(() => {
         setValue((val) => onTick(val));
       }, interval);
     }
     if (end(value)) {
-      window.clearInterval(timerRef.current);
+      clearInterval(timerRef.current);
       onEnd(value);
     }
   }, [end, interval, onEnd, onTick, value]);
 
   useEffect(() => () => {
-    window.clearInterval(timerRef.current);
+    clearInterval(timerRef.current);
   }, []);
 
   return children(value);


### PR DESCRIPTION
This pr removes the usage of the window object, so that `setInterval` and `clearInterval` can be executed based on their runtime environment. 

Why? 

This change adds compatibility for `react-native` as well